### PR TITLE
Handle cases where branch is not available

### DIFF
--- a/oogg/repository.py
+++ b/oogg/repository.py
@@ -49,7 +49,15 @@ class Repository:
             capture_output=True,
         )
 
-        return out.stdout.strip().decode("utf-8")
+        branch_name = out.stdout.strip().decode("utf-8")
+        if not branch_name:
+            out = subprocess.run(
+                ("git", "rev-parse", "HEAD"),
+                capture_output=True,
+            )
+
+            branch_name = out.stdout.strip().decode("utf-8")
+        return branch_name
 
     def parse(self) -> "Repository":
         """Parse the necessary values for this class

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -27,10 +27,7 @@ def test_repository__get_remote_url(subprocess_run_mock, stdout, expected):
 
 @pytest.mark.parametrize(
     ("stdout", "expected"),
-    (
-        (b"test\n", "test"),
-        (b"test", "test"),
-    ),
+    ((b"test\n", "test"), (b"test", "test"), (b"", "")),
 )
 @mock.patch("subprocess.run")
 def test_repository__get_remote_branch(subprocess_run_mock, stdout, expected):


### PR DESCRIPTION
If the branch is not available, then we tr to get the latest commit,
which probably they are in a detached state.

Solves #14

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>